### PR TITLE
Edits to change other CLIs to use ignore-ecc-bounds-exceedance argument

### DIFF
--- a/improver/cli/apply_emos_coefficients.py
+++ b/improver/cli/apply_emos_coefficients.py
@@ -44,7 +44,7 @@ def process(
     realizations_count: int = None,
     randomise=False,
     random_seed: int = None,
-    ignore_ecc_bounds=False,
+    ignore_ecc_bounds_exceedance=False,
     tolerate_time_mismatch=False,
     predictor="mean",
     land_sea_mask_name: str = None,
@@ -106,7 +106,7 @@ def process(
             ensemble, or for splitting tied values within the raw ensemble,
             so that the values from the input percentiles can be ordered to
             match the raw ensemble.
-        ignore_ecc_bounds (bool):
+        ignore_ecc_bounds_exceedance (bool):
             If True, where the percentiles exceed the ECC bounds range,
             raises a warning rather than an exception. This occurs when the
             current forecasts is in the form of probabilities and is
@@ -160,9 +160,9 @@ def process(
             # Ensure that a consistent set of percentiles are returned,
             # regardless of whether EMOS is successfully applied.
             percentiles = [np.float32(p) for p in percentiles]
-            forecast = ResamplePercentiles(ecc_bounds_warning=ignore_ecc_bounds)(
-                forecast, percentiles=percentiles
-            )
+            forecast = ResamplePercentiles(
+                ecc_bounds_warning=ignore_ecc_bounds_exceedance
+            )(forecast, percentiles=percentiles)
         elif prob_template:
             forecast = prob_template
         forecast = add_warning_comment(forecast)
@@ -185,9 +185,9 @@ def process(
             # Ensure that a consistent set of percentiles are returned,
             # regardless of whether EMOS is successfully applied.
             percentiles = [np.float32(p) for p in percentiles]
-            forecast = ResamplePercentiles(ecc_bounds_warning=ignore_ecc_bounds)(
-                forecast, percentiles=percentiles
-            )
+            forecast = ResamplePercentiles(
+                ecc_bounds_warning=ignore_ecc_bounds_exceedance
+            )(forecast, percentiles=percentiles)
 
         msg = (
             "There are no coefficients provided for calibration. The "
@@ -206,7 +206,7 @@ def process(
         land_sea_mask=land_sea_mask,
         prob_template=prob_template,
         realizations_count=realizations_count,
-        ignore_ecc_bounds=ignore_ecc_bounds,
+        ignore_ecc_bounds=ignore_ecc_bounds_exceedance,
         tolerate_time_mismatch=tolerate_time_mismatch,
         predictor=predictor,
         randomise=randomise,

--- a/improver/cli/generate_percentiles.py
+++ b/improver/cli/generate_percentiles.py
@@ -41,7 +41,7 @@ def process(
     *,
     coordinates: cli.comma_separated_list = None,
     percentiles: cli.comma_separated_list = None,
-    ignore_ecc_bounds=False,
+    ignore_ecc_bounds_exceedance=False,
 ):
     r"""Collapses cube coordinates and calculate percentiled data.
 
@@ -68,7 +68,7 @@ def process(
             coordinate.
         percentiles (list):
             Optional definition of percentiles at which to calculate data.
-        ignore_ecc_bounds (bool):
+        ignore_ecc_bounds_exceedance (bool):
             If True, where calculated percentiles are outside the ECC bounds
             range, raises a warning rather than an exception.
 
@@ -101,7 +101,7 @@ def process(
 
     if is_probability(cube):
         result = ConvertProbabilitiesToPercentiles(
-            ecc_bounds_warning=ignore_ecc_bounds
+            ecc_bounds_warning=ignore_ecc_bounds_exceedance
         )(cube, percentiles=percentiles)
         if coordinates:
             warnings.warn(

--- a/improver/cli/spot_extract.py
+++ b/improver/cli/spot_extract.py
@@ -42,7 +42,7 @@ def process(
     land_constraint=False,
     similar_altitude=False,
     extract_percentiles: cli.comma_separated_list = None,
-    ignore_ecc_bounds=False,
+    ignore_ecc_bounds_exceedance=False,
     new_title: str = None,
     suppress_warnings=False,
     realization_collapse=False,
@@ -159,7 +159,7 @@ def process(
         except CoordinateNotFoundError:
             if "probability_of_" in result.name():
                 result = ConvertProbabilitiesToPercentiles(
-                    ecc_bounds_warning=ignore_ecc_bounds
+                    ecc_bounds_warning=ignore_ecc_bounds_exceedance
                 )(result, percentiles=extract_percentiles)
                 result = iris.util.squeeze(result)
             elif result.coords("realization", dim_coords=True):

--- a/improver_tests/acceptance/test_generate_percentiles.py
+++ b/improver_tests/acceptance/test_generate_percentiles.py
@@ -93,7 +93,7 @@ def test_eccbounds(tmp_path):
         "realization",
         "--percentiles",
         "25,50,75",
-        "--ignore-ecc-bounds",
+        "--ignore-ecc-bounds-exceedance",
     ]
     with pytest.warns(UserWarning, match="The calculated threshold values"):
         run_cli(args)


### PR DESCRIPTION
Related to https://github.com/metoppv/improver/issues/1835, https://github.com/metoppv/improver/pull/1838

Description
This PR updates CLIs other than `generate-realizations` by renaming the `ignore-ecc-bounds` argument to be `ignore-ecc-bounds-exceedance`. This is primarily intended to give greater clarity regarding the difference between the `ignore-ecc-bounds-exceedance` argument and the `skip-ecc-bounds` argument. 

Testing:
 - [x] Ran tests and they passed OK
 - [x] Added new tests for the new feature(s)

